### PR TITLE
Feature/collation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,21 @@ your_profile_name:
       username: your_mysql_username
       password: your_mysql_password
       ssl_disabled: True
+      charset: utf8mb4
+      collation: utf8mb4_0900_ai_ci
 ```
 
 | Option          | Description                                                                         | Required?                                                          | Example                                        |
 | --------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
-| type            | The specific adapter to use                                                         | Required                                                           | `mysql`, `mysql5` or `mariadb`                            |
+| type            | The specific adapter to use                                                         | Required                                                           | `mysql`, `mysql5` or `mariadb`                 |
 | server          | The server (hostname) to connect to                                                 | Required                                                           | `yourorg.mysqlhost.com`                        |
 | port            | The port to use                                                                     | Optional                                                           | `3306`                                         |
 | schema          | Specify the schema (database) to build models into                                  | Required                                                           | `analytics`                                    |
 | username        | The username to use to connect to the server                                        | Required                                                           | `dbt_admin`                                    |
 | password        | The password to use for authenticating to the server                                | Required                                                           | `correct-horse-battery-staple`                 |
 | ssl_disabled    | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `True` or `False`                              |
+| charset         | Specify charset to be used by a connection                                          | Optional                                                           | `utf8mb4`                                      |
+| collation       | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `utf8mb4_0900_ai_ci`                           |
 
 ### Notes
 

--- a/dbt/adapters/mysql/__version__.py
+++ b/dbt/adapters/mysql/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0a1"
+version = "1.7.0aX"

--- a/dbt/adapters/mysql/__version__.py
+++ b/dbt/adapters/mysql/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0a2"
+version = "1.7.0a1"

--- a/dbt/adapters/mysql/__version__.py
+++ b/dbt/adapters/mysql/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0aX"
+version = "1.7.0a2"

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -107,6 +107,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
             connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+            connection.handle = None
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -107,7 +107,6 @@ class MySQLConnectionManager(SQLConnectionManager):
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
             connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
-            connection.handle = None
         except mysql.connector.Error:
             try:
                 logger.debug(
@@ -120,6 +119,7 @@ class MySQLConnectionManager(SQLConnectionManager):
 
                 connection.handle = mysql.connector.connect(**kwargs)
                 connection.state = "open"
+                connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
             except mysql.connector.Error as e:
                 logger.debug(
                     "Got an error when attempting to open a mysql " "connection: '{}'".format(e)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -95,13 +95,19 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
+        # if credentials.charset:
+        #     kwargs["charset"] = credentials.charset
+
+        # if credentials.collation:
+        #     kwargs["collation"] = credentials.collation
+
         try:
             connection.handle = mysql.connector.connect(**kwargs)
-            if credentials.charset:
-                if credentials.collation:
-                    connection.handle.set_charset_collation(credentials.charset, credentials.collation)
-                else:
-                    connection.handle.set_charset_collation(credentials.charset)
+            # if credentials.charset:
+            #     if credentials.collation:
+            #         connection.handle.set_charset_collation(credentials.charset, credentials.collation)
+            #     else:
+            #         connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
             # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -103,11 +103,11 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)
-            # if credentials.charset:
-            #     if credentials.collation:
-            #         connection.handle.set_charset_collation(credentials.charset, credentials.collation)
-            #     else:
-            #         connection.handle.set_charset_collation(credentials.charset)
+            if credentials.charset:
+                if credentials.collation:
+                    connection.handle.set_charset_collation(credentials.charset, credentials.collation)
+                else:
+                    connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
             # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -14,6 +14,7 @@ from typing import Optional, Union
 
 logger = AdapterLogger("mysql")
 
+
 @dataclass(init=False)
 class MySQLCredentials(Credentials):
     server: str = ""

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -75,7 +75,6 @@ class MySQLConnectionManager(SQLConnectionManager):
 
     @classmethod
     def open(cls, connection):
-
         if connection.state == "open":
             logger.debug("Connection is already open, skipping open.")
             return connection
@@ -104,7 +103,6 @@ class MySQLConnectionManager(SQLConnectionManager):
         try:
             connection.handle = mysql.connector.connect(**kwargs)
             connection.state = "open"
-
         except mysql.connector.Error:
             try:
                 logger.debug(
@@ -117,7 +115,6 @@ class MySQLConnectionManager(SQLConnectionManager):
 
                 connection.handle = mysql.connector.connect(**kwargs)
                 connection.state = "open"
-
             except mysql.connector.Error as e:
                 logger.debug(
                     "Got an error when attempting to open a mysql " "connection: '{}'".format(e)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -94,11 +94,11 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        # if credentials.charset:
-        #     kwargs["charset"] = credentials.charset
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
 
-        # if credentials.collation:
-        #     kwargs["collation"] = credentials.collation
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -95,9 +95,6 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        if credentials.collation:
-            kwargs["collation"] = credentials.collation
-
         try:
             connection.handle = mysql.connector.connect(**kwargs)
             if credentials.charset:
@@ -106,7 +103,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 else:
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
-            connection.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+            connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -105,7 +105,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                     connection.handle.set_charset_collation(credentials.charset, credentials.collation)
                 else:
                     connection.handle.set_charset_collation(credentials.charset)
-                connection.state = "open"
+            connection.state = "open"
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -25,6 +25,7 @@ class MySQLCredentials(Credentials):
     username: Optional[str] = None
     password: Optional[str] = None
     charset: Optional[str] = None
+    collation: Optional[str] = None
 
     _ALIASES = {
         "UID": "username",
@@ -93,6 +94,12 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         if credentials.port:
             kwargs["port"] = credentials.port
+
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
+
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -95,11 +95,11 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        # if credentials.charset:
-        #     kwargs["charset"] = credentials.charset
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
 
-        # if credentials.collation:
-        #     kwargs["collation"] = credentials.collation
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -94,11 +94,11 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        if credentials.charset:
-            kwargs["charset"] = credentials.charset
+        # if credentials.charset:
+        #     kwargs["charset"] = credentials.charset
 
-        if credentials.collation:
-            kwargs["collation"] = credentials.collation
+        # if credentials.collation:
+        #     kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -106,7 +106,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 else:
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
-            connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+            connection.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:
             try:
                 logger.debug(
@@ -119,7 +119,7 @@ class MySQLConnectionManager(SQLConnectionManager):
 
                 connection.handle = mysql.connector.connect(**kwargs)
                 connection.state = "open"
-                connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+                # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
             except mysql.connector.Error as e:
                 logger.debug(
                     "Got an error when attempting to open a mysql " "connection: '{}'".format(e)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -76,8 +76,6 @@ class MySQLConnectionManager(SQLConnectionManager):
     @classmethod
     def open(cls, connection):
 
-        raise Exception("Failing on purpose")
-
         if connection.state == "open":
             logger.debug("Connection is already open, skipping open.")
             return connection

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -14,7 +14,6 @@ from typing import Optional, Union
 
 logger = AdapterLogger("mysql")
 
-
 @dataclass(init=False)
 class MySQLCredentials(Credentials):
     server: str = ""
@@ -76,6 +75,9 @@ class MySQLConnectionManager(SQLConnectionManager):
 
     @classmethod
     def open(cls, connection):
+
+        raise Exception("Failing on purpose")
+
         if connection.state == "open":
             logger.debug("Connection is already open, skipping open.")
             return connection

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -103,11 +103,11 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)
-            if credentials.charset:
-                if credentials.collation:
-                    connection.handle.set_charset_collation(credentials.charset, credentials.collation)
-                else:
-                    connection.handle.set_charset_collation(credentials.charset)
+            # if credentials.charset:
+            #     if credentials.collation:
+            #         connection.handle.set_charset_collation(credentials.charset, credentials.collation)
+            #     else:
+            #         connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
             # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -103,13 +103,8 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)
-            # if credentials.charset:
-            #     if credentials.collation:
-            #         connection.handle.set_charset_collation(credentials.charset, credentials.collation)
-            #     else:
-            #         connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
-            # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+
         except mysql.connector.Error:
             try:
                 logger.debug(
@@ -122,7 +117,7 @@ class MySQLConnectionManager(SQLConnectionManager):
 
                 connection.handle = mysql.connector.connect(**kwargs)
                 connection.state = "open"
-                # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+
             except mysql.connector.Error as e:
                 logger.debug(
                     "Got an error when attempting to open a mysql " "connection: '{}'".format(e)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -106,6 +106,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 else:
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
+            connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -103,7 +103,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 else:
                     connection.handle.set_charset_collation(credentials.charset)
             connection.state = "open"
-            connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
+            # connection.handle.set_charset_collation("utf8mb4", "utf8mb4_0900_ai_ci")
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -95,15 +95,17 @@ class MySQLConnectionManager(SQLConnectionManager):
         if credentials.port:
             kwargs["port"] = credentials.port
 
-        if credentials.charset:
-            kwargs["charset"] = credentials.charset
-
         if credentials.collation:
             kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)
-            connection.state = "open"
+            if credentials.charset:
+                if credentials.collation:
+                    connection.handle.set_charset_collation(credentials.charset, credentials.collation)
+                else:
+                    connection.handle.set_charset_collation(credentials.charset)
+                connection.state = "open"
         except mysql.connector.Error:
             try:
                 logger.debug(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-mysql"
-package_version = "1.7.0a2"
+package_version = "1.7.0a1"
 dbt_core_version = _get_dbt_core_version()
 description = """The MySQL adapter plugin for dbt"""
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-mysql"
-package_version = "1.7.0a1"
+package_version = "1.7.0a2"
 dbt_core_version = _get_dbt_core_version()
 description = """The MySQL adapter plugin for dbt"""
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "mysql-connector-python>=8.0.0,<8.2",
+        "mysql-connector-python==8.1",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "mysql-connector-python>=8.0.0,<8.1",
+        "mysql-connector-python>=8.0.0,<8.2",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description
1. Bumped mysql-connector-python to 8.1, because previous version was by default using incorrect collation for charset `utf8mb4` which was `utf8mb4_general_ci`. The correct default one is `utf8mb4_0900_ci_ai` and 8.1 version uses it by default.
2. Added support for overriding charset and collation via `profiles.yml` which is useful if someone wants to use different charsets and collations by default
3. Adjusted readme with examples of new settings
4. I've run all the tests and they passed

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
